### PR TITLE
Use SwimSpeed as FlySpeed in vanilla

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -772,6 +772,11 @@ namespace HermesProxy.World.Client
                     moveInfo.FlightSpeed = packet.ReadFloat();
                     moveInfo.FlightBackSpeed = packet.ReadFloat();
                 }
+                else
+                { // Convenience in vanilla to use SwimSpeed as FlySpeed
+                    moveInfo.FlightSpeed = moveInfo.SwimSpeed;
+                    moveInfo.FlightBackSpeed = moveInfo.SwimBackSpeed;
+                }
                 moveInfo.TurnRate = packet.ReadFloat();
                 if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
                     moveInfo.PitchRate = packet.ReadFloat();

--- a/HermesProxy/World/Enums/MovementFlags.cs
+++ b/HermesProxy/World/Enums/MovementFlags.cs
@@ -104,6 +104,7 @@ namespace HermesProxy.World.Enums
         LocalDirty         = 0x80000000
     }
 
+    [Flags]
     public enum MovementFlagModern : uint
     {
         None               = 0x00000000,

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -88,7 +88,13 @@ namespace HermesProxy.World.Server
         [PacketHandler(Opcode.CMSG_MOVE_FORCE_WALK_SPEED_CHANGE_ACK)]
         void HandleMoveForceSpeedChangeAck(MovementSpeedAck speed)
         {
-            WorldPacket packet = new WorldPacket(speed.GetUniversalOpcode());
+            var opcode = speed.GetUniversalOpcode();
+            if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180)
+                && opcode is Opcode.CMSG_MOVE_FORCE_FLIGHT_SPEED_CHANGE_ACK
+                          or Opcode.CMSG_MOVE_FORCE_FLIGHT_BACK_SPEED_CHANGE_ACK)
+                return; // This is probably an ack by our swim to fly speed change for vanilla
+
+            WorldPacket packet = new WorldPacket(opcode);
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_2_0_10192))
                 packet.WritePackedGuid(speed.MoverGUID.To64());
             else


### PR DESCRIPTION
I know that this is probably a controversial change, but in Vanilla there was no concept of flying / flyspeed.
Many emulators tell the client to swim mid air and thus the "flyspeed" was set via swimspeed.

In this commit I propose to always set the flyspeed when the swimspeed changes.
Allowing users of the modern client to adjust their flyspeed.
