### PR TITLE
Add Threat API Packet Handling

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
@@ -153,5 +153,51 @@ namespace HermesProxy.World.Client
             log.Victim = packet.ReadGuid().To128(GetSession().GameState);
             SendPacketToClient(log);
         }
+        [PacketHandler(Opcode.SMSG_THREAT_UPDATE)]
+        void HandleThreatUpdate(WorldPacket packet)
+        {
+            ThreatUpdate update = new();
+            update.UnitGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
+            update.ThreatListCount = packet.ReadUInt32();
+            for (int i = 0; i < update.ThreatListCount; i++)
+            {
+                var temp = new ThreatInfo();
+                temp.UnitGUID = packet.ReadPackedGuid128().To128(GetSession().GameState);
+                temp.Threat = (int)packet.ReadUInt32();
+                update.ThreatList.Add(temp);
+            }
+            SendPacketToClient(update);
+        }
+        [PacketHandler(Opcode.SMSG_HIGHEST_THREAT_UPDATE)]
+        void HandleHighestThreatUpdate(WorldPacket packet)
+        {
+            HighestThreatUpdate update = new();
+            update.UnitGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
+            update.HighestThreatGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
+            update.ThreatListCount = packet.ReadUInt32();
+            for (int i = 0; i < update.ThreatListCount; i++)
+            {
+                var temp = new ThreatInfo();
+                temp.UnitGUID = packet.ReadPackedGuid128().To128(GetSession().GameState);
+                temp.Threat = (int)packet.ReadUInt32();
+                update.ThreatList.Add(temp);
+            }
+            SendPacketToClient(update);
+        }
+        [PacketHandler(Opcode.SMSG_THREAT_CLEAR)]
+        void HandleThreatClear(WorldPacket packet)
+        {
+            ThreatClear clear = new();
+            clear.UnitGUID = packet.ReadPackedGuid128().To128(GetSession().GameState);
+            SendPacketToClient(clear);
+        }
+        [PacketHandler(Opcode.SMSG_THREAT_REMOVE)]
+        void HandleThreatRemove(WorldPacket packet)
+        {
+            ThreatRemove remove = new();
+            remove.UnitGUID = packet.ReadPackedGuid128().To128(GetSession().GameState);
+            remove.AboutGUID = packet.ReadPackedGuid128().To128(GetSession().GameState);
+            SendPacketToClient(remove);
+        }
     }
 }

--- a/HermesProxy/World/Server/Packets/CombatPackets.cs
+++ b/HermesProxy/World/Server/Packets/CombatPackets.cs
@@ -282,4 +282,71 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 Player;
         public WowGuid128 Victim;
     }
+
+    public struct ThreatInfo
+    {
+        public WowGuid128 UnitGUID;
+        public int Threat;
+    }
+
+    class ThreatUpdate : ServerPacket
+    {
+        public ThreatUpdate() : base(Opcode.SMSG_THREAT_UPDATE) { }
+        public override void Write()
+        {
+            _worldPacket.WritePackedGuid128(UnitGUID);
+            _worldPacket.WriteUInt32(ThreatListCount);
+            foreach (var info in ThreatList)
+            {
+                _worldPacket.WritePackedGuid128(info.UnitGUID);
+                _worldPacket.WriteInt32(info.Threat);
+            }
+        }
+        public WowGuid128 UnitGUID;
+        public uint ThreatListCount;
+        public Array<ThreatInfo> ThreatList;
+    }
+
+    class HighestThreatUpdate : ServerPacket
+    {
+        public HighestThreatUpdate() : base(Opcode.SMSG_HIGHEST_THREAT_UPDATE) { }
+        public override void Write()
+        {
+            _worldPacket.WritePackedGuid128(UnitGUID);
+            _worldPacket.WritePackedGuid128(HighestThreatGUID);
+            _worldPacket.WriteUInt32(ThreatListCount);
+            foreach (var info in ThreatList)
+            {
+                _worldPacket.WritePackedGuid128(info.UnitGUID);
+                _worldPacket.WriteInt32(info.Threat);
+            }
+        }
+        public WowGuid128 UnitGUID;
+        public WowGuid128 HighestThreatGUID;
+        public uint ThreatListCount;
+        public Array<ThreatInfo> ThreatList;
+    }
+
+    class ThreatClear : ServerPacket
+    {
+        public ThreatClear() : base(Opcode.SMSG_THREAT_CLEAR) { }
+        public override void Write()
+        {
+            _worldPacket.WritePackedGuid128(UnitGUID);
+        }
+        public WowGuid128 UnitGUID;
+    }
+
+    class ThreatRemove : ServerPacket
+    {
+        public ThreatRemove() : base(Opcode.SMSG_THREAT_REMOVE) { }
+
+        public override void Write()
+        {
+            _worldPacket.WritePackedGuid128(UnitGUID);
+            _worldPacket.WritePackedGuid128(AboutGUID);
+        }
+        public WowGuid128 UnitGUID;
+        public WowGuid128 AboutGUID;
+    }
 }


### PR DESCRIPTION
This PR adds handlers for Threat API Opcodes.
They are currently unimplemented on CMaNGOS, not sure about the status on VMaNGOS but I believe also not implemented; but someone may decide to add the API to their implementation of the server, hence this.

This PR does explicitly *not* define the values for these Opcodes, as I don't want to define values for them, without making sure that these values don't collide with other Opcode-Values or cause any other issue.

I'll leave the PR in draft, and request comments/suggestions on how to proceed. (I am not entirely sure which data-type the Threat values are supposed to be. The TrinityCore project seems to believe they are 64 bit signed integers ( https://github.com/TrinityCore/TrinityCore/blob/wotlk_classic/src/server/game/Server/Packets/CombatPackets.h#L94 ), but I couldn't independently verify this.)