### PR TITLE
Add CMSG_WRAP_ITEM handler

### DIFF
--- a/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
@@ -196,5 +196,16 @@ namespace HermesProxy.World.Server
             packet.WriteUInt32(cancel.EnchantmentSlot);
             SendPacketToServer(packet);
         }
+
+        [PacketHandler(Opcode.CMSG_WRAP_ITEM)]
+        void HandleWrapItem(WrapItem item)
+        {
+            WorldPacket packet = new WorldPacket(Opcode.CMSG_WRAP_ITEM);
+            packet.WriteUInt8(item.gift_bag);
+            packet.WriteUInt8(item.gift_slot);
+            packet.WriteUInt8(item.item_bag);
+            packet.WriteUInt8(item.item_slot);
+            SendPacketToServer(packet);
+        }
     }
 }

--- a/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
@@ -201,10 +201,10 @@ namespace HermesProxy.World.Server
         void HandleWrapItem(WrapItem item)
         {
             WorldPacket packet = new WorldPacket(Opcode.CMSG_WRAP_ITEM);
-            packet.WriteUInt8(item.gift_bag);
-            packet.WriteUInt8(item.gift_slot);
-            packet.WriteUInt8(item.item_bag);
-            packet.WriteUInt8(item.item_slot);
+            packet.WriteUInt8(item.GiftBag);
+            packet.WriteUInt8(item.GiftSlot);
+            packet.WriteUInt8(item.ItemBag);
+            packet.WriteUInt8(item.ItemSlot);
             SendPacketToServer(packet);
         }
     }

--- a/HermesProxy/World/Server/Packets/ItemPackets.cs
+++ b/HermesProxy/World/Server/Packets/ItemPackets.cs
@@ -694,12 +694,16 @@ namespace HermesProxy.World.Server.Packets
 
         public override void Read()
         {
-            _worldPacket.ReadUInt8(); // Unknown Value. Usually 128
-            gift_bag = _worldPacket.ReadUInt8();
-            gift_slot = _worldPacket.ReadUInt8();
-            item_bag = _worldPacket.ReadUInt8();
-            item_slot = _worldPacket.ReadUInt8();
+            _ = _worldPacket.ReadUInt8(); // Unknown Value. Usually 128
+            GiftBag = _worldPacket.ReadUInt8();
+            GiftSlot = _worldPacket.ReadUInt8();
+            ItemBag = _worldPacket.ReadUInt8();
+            ItemSlot = _worldPacket.ReadUInt8();
         }
-        public byte gift_bag, gift_slot, item_bag, item_slot;
+        
+        public byte GiftBag { get; set; }
+        public byte GiftSlot { get; set; }
+        public byte ItemBag { get; set; }
+        public byte ItemSlot { get; set; }
     }
 }

--- a/HermesProxy/World/Server/Packets/ItemPackets.cs
+++ b/HermesProxy/World/Server/Packets/ItemPackets.cs
@@ -687,4 +687,19 @@ namespace HermesProxy.World.Server.Packets
 
         public uint EnchantmentSlot;
     }
+
+    public class WrapItem : ClientPacket
+    {
+        public WrapItem(WorldPacket packet) : base(packet) { }
+
+        public override void Read()
+        {
+            _worldPacket.ReadUInt8(); // Unknown Value. Usually 128
+            gift_bag = _worldPacket.ReadUInt8();
+            gift_slot = _worldPacket.ReadUInt8();
+            item_bag = _worldPacket.ReadUInt8();
+            item_slot = _worldPacket.ReadUInt8();
+        }
+        public byte gift_bag, gift_slot, item_bag, item_slot;
+    }
 }


### PR DESCRIPTION
This PR adds a handler for `CMSG_WRAP_ITEM`.

Since the serverside handler for vmangos and cmangos-tbc for `CMSG_WRAP_ITEM` are the same, I assume this will will work for both of them.

The byte values are preceded by an unknown byte that contains the value "128". I have no idea what that does, but ignoring it makes this work :shrug: 