### PR TITLE
Fix InventoryResult off by one error

### DIFF
--- a/HermesProxy/VersionChecker.cs
+++ b/HermesProxy/VersionChecker.cs
@@ -309,7 +309,7 @@ namespace HermesProxy
         {
             if (RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
                 return (InventoryResult)Enum.Parse(typeof(InventoryResult), ((InventoryResultVanilla)result).ToString());
-            else if (AddedInVersion(ClientVersionBuild.V2_0_1_6180))
+            else
                 return (InventoryResult)Enum.Parse(typeof(InventoryResult), ((InventoryResultTBC)result).ToString());
 
             return (InventoryResult)result;

--- a/HermesProxy/VersionChecker.cs
+++ b/HermesProxy/VersionChecker.cs
@@ -309,6 +309,8 @@ namespace HermesProxy
         {
             if (RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
                 return (InventoryResult)Enum.Parse(typeof(InventoryResult), ((InventoryResultVanilla)result).ToString());
+            else if (AddedInVersion(ClientVersionBuild.V2_0_1_6180))
+                return (InventoryResult)Enum.Parse(typeof(InventoryResult), ((InventoryResultTBC)result).ToString());
 
             return (InventoryResult)result;
         }

--- a/HermesProxy/World/Enums/ItemDefines.cs
+++ b/HermesProxy/World/Enums/ItemDefines.cs
@@ -270,6 +270,91 @@ namespace HermesProxy.World.Enums
         LootCantLootThatNow,
     };
 
+    public enum InventoryResultTBC
+    {
+        Ok = 0,
+        CantEquipLevel,  // You Must Reach Level %D To Use That Item.
+        CantEquipSkill,  // You Aren'T Skilled Enough To Use That Item.
+        WrongSlot,  // That Item Does Not Go In That Slot.
+        BagFull,  // That Bag Is Full.
+        BagInBag,  // Can'T Put Non-Empty Bags In Other Bags.
+        TradeEquippedBag,  // You Can'T Trade Equipped Bags.
+        AmmoOnly,  // Only Ammo Can Go There.
+        ProficiencyNeeded,  // You Do Not Have The Required Proficiency For That Item.
+        NoSlotAvailable,  // No Equipment Slot Is Available For That Item.
+        CantEquipEver, // You Can Never Use That Item.
+        CantEquipEver2, // You Can Never Use That Item.
+        NoSlotAvailable2, // No Equipment Slot Is Available For That Item.
+        Equipped2handed, // Cannot Equip That With A Two-Handed Weapon.
+        TwoHandSkillNotFound, // You Cannot Dual-Wield
+        WrongBagType, // That Item Doesn'T Go In That Container.
+        WrongBagType2, // That Item Doesn'T Go In That Container.
+        ItemMaxCount, // You Can'T Carry Any More Of Those Items.
+        NoSlotAvailable3, // No Equipment Slot Is Available For That Item.
+        CantStack, // This Item Cannot Stack.
+        NotEquippable, // This Item Cannot Be Equipped.
+        CantSwap, // These Items Can'T Be Swapped.
+        SlotEmpty, // That Slot Is Empty.
+        ItemNotFound, // The Item Was Not Found.
+        DropBoundItem, // You Can'T Drop A Soulbound Item.
+        OutOfRange, // Out Of Range.
+        TooFewToSplit, // Tried To Split More Than Number In Stack.
+        SplitFailed, // Couldn'T Split Those Items.
+        SpellFailedReagentsGeneric, // Missing Reagent
+        NotEnoughMoney, // You Don'T Have Enough Money.
+        NotABag, // Not A Bag.
+        DestroyNonemptyBag, // You Can Only Do That With Empty Bags.
+        NotOwner, // You Don'T Own That Item.
+        OnlyOneQuiver, // You Can Only Equip One Quiver.
+        NoBankSlot, // You Must Purchase That Bag Slot First
+        NoBankHere, // You Are Too Far Away From A Bank.
+        ItemLocked, // Item Is Locked.
+        GenericStunned, // You Are Stunned
+        PlayerDead, // You Can'T Do That When You'Re Dead.
+        ClientLockedOut, // You Can'T Do That Right Now.
+        InternalBagError, // Internal Bag Error
+        OnlyOneBolt, // You Can Only Equip One Quiver.
+        OnlyOneAmmo, // You Can Only Equip One Ammo Pouch.
+        CantWrapStackable, // Stackable Items Can'T Be Wrapped.
+        CantWrapEquipped, // Equipped Items Can'T Be Wrapped.
+        CantWrapWrapped, // Wrapped Items Can'T Be Wrapped.
+        CantWrapBound, // Bound Items Can'T Be Wrapped.
+        CantWrapUnique, // Unique Items Can'T Be Wrapped.
+        CantWrapBags, // Bags Can'T Be Wrapped.
+        LootGone, // Already Looted
+        InvFull, // Inventory Is Full.
+        BankFull, // Your Bank Is Full
+        VendorSoldOut, // That Item Is Currently Sold Out.
+        BagFull2, // That Bag Is Full.
+        ItemNotFound2, // The Item Was Not Found.
+        CantStack2, // This Item Cannot Stack.
+        BagFull3, // That Bag Is Full.
+        VendorSoldOut2, // That Item Is Currently Sold Out.
+        ObjectIsBusy, // That Object Is Busy.
+        CantBeDisenchanted, // Item Cannot Be Disenchanted
+        NotInCombat, // You Can'T Do That While In Combat
+        NotWhileDisarmed, // You Can'T Do That While Disarmed
+        BagFull4, // That Bag Is Full.
+        CantEquipRank, // You Don'T Have The Required Rank For That Item
+        CantEquipReputation, // You Don'T Have The Required Reputation For That Item
+        TooManySpecialBags, // You Cannot Equip Another Bag Of That Type
+        LootCantLootThatNow, // You Can'T Loot That Item Now.
+        ItemUniqueEquippable, // You Cannot Equip More Than One Of Those.
+        VendorMissingTurnins, // You Do Not Have The Required Items For That Purchase
+        NotEnoughHonorPoints, // You Don'T Have Enough Honor Points
+        NotEnoughArenaPoints, // You Don'T Have Enough Arena Points
+        ItemMaxCountSocketed, // You Have The Maximum Number Of Those Gems In Your Inventory Or Socketed Into Items.
+        MailBoundItem, // You Can'T Mail Soulbound Items.
+        InternalBagError2, // Internal Bag Error
+        BagFull5, // That Bag Is Full.
+        ItemMaxCountEquippedSocketed, // You Have The Maximum Number Of Those Gems Socketed Into Equipped Items.
+        ItemUniqueEquippableSocketed, // You Cannot Socket More Than One Of Those Gems Into A Single Item.
+        TooMuchGold, // At Gold Limit
+        NotDuringArenaMatch, // You Can'T Do That While In An Arena Match
+        TradeBoundItem, // You Can'T Trade A Soulbound Item.
+        CantEquipRating, // You Don'T Have The Personal, Team, Or Battleground Rating Required To Buy That Item
+    };
+
     public enum InventoryResult
     {
         Ok = 0,

--- a/HermesProxy/World/Enums/ItemDefines.cs
+++ b/HermesProxy/World/Enums/ItemDefines.cs
@@ -273,86 +273,86 @@ namespace HermesProxy.World.Enums
     public enum InventoryResultTBC
     {
         Ok = 0,
-        CantEquipLevel,  // You Must Reach Level %D To Use That Item.
-        CantEquipSkill,  // You Aren'T Skilled Enough To Use That Item.
-        WrongSlot,  // That Item Does Not Go In That Slot.
-        BagFull,  // That Bag Is Full.
-        BagInBag,  // Can'T Put Non-Empty Bags In Other Bags.
-        TradeEquippedBag,  // You Can'T Trade Equipped Bags.
-        AmmoOnly,  // Only Ammo Can Go There.
-        ProficiencyNeeded,  // You Do Not Have The Required Proficiency For That Item.
-        NoSlotAvailable,  // No Equipment Slot Is Available For That Item.
-        CantEquipEver, // You Can Never Use That Item.
-        CantEquipEver2, // You Can Never Use That Item.
-        NoSlotAvailable2, // No Equipment Slot Is Available For That Item.
-        Equipped2handed, // Cannot Equip That With A Two-Handed Weapon.
-        TwoHandSkillNotFound, // You Cannot Dual-Wield
-        WrongBagType, // That Item Doesn'T Go In That Container.
-        WrongBagType2, // That Item Doesn'T Go In That Container.
-        ItemMaxCount, // You Can'T Carry Any More Of Those Items.
-        NoSlotAvailable3, // No Equipment Slot Is Available For That Item.
-        CantStack, // This Item Cannot Stack.
-        NotEquippable, // This Item Cannot Be Equipped.
-        CantSwap, // These Items Can'T Be Swapped.
-        SlotEmpty, // That Slot Is Empty.
-        ItemNotFound, // The Item Was Not Found.
-        DropBoundItem, // You Can'T Drop A Soulbound Item.
-        OutOfRange, // Out Of Range.
-        TooFewToSplit, // Tried To Split More Than Number In Stack.
-        SplitFailed, // Couldn'T Split Those Items.
-        SpellFailedReagentsGeneric, // Missing Reagent
-        NotEnoughMoney, // You Don'T Have Enough Money.
-        NotABag, // Not A Bag.
-        DestroyNonemptyBag, // You Can Only Do That With Empty Bags.
-        NotOwner, // You Don'T Own That Item.
-        OnlyOneQuiver, // You Can Only Equip One Quiver.
-        NoBankSlot, // You Must Purchase That Bag Slot First
-        NoBankHere, // You Are Too Far Away From A Bank.
-        ItemLocked, // Item Is Locked.
-        GenericStunned, // You Are Stunned
-        PlayerDead, // You Can'T Do That When You'Re Dead.
-        ClientLockedOut, // You Can'T Do That Right Now.
-        InternalBagError, // Internal Bag Error
-        OnlyOneBolt, // You Can Only Equip One Quiver.
-        OnlyOneAmmo, // You Can Only Equip One Ammo Pouch.
-        CantWrapStackable, // Stackable Items Can'T Be Wrapped.
-        CantWrapEquipped, // Equipped Items Can'T Be Wrapped.
-        CantWrapWrapped, // Wrapped Items Can'T Be Wrapped.
-        CantWrapBound, // Bound Items Can'T Be Wrapped.
-        CantWrapUnique, // Unique Items Can'T Be Wrapped.
-        CantWrapBags, // Bags Can'T Be Wrapped.
-        LootGone, // Already Looted
-        InvFull, // Inventory Is Full.
-        BankFull, // Your Bank Is Full
-        VendorSoldOut, // That Item Is Currently Sold Out.
-        BagFull2, // That Bag Is Full.
-        ItemNotFound2, // The Item Was Not Found.
-        CantStack2, // This Item Cannot Stack.
-        BagFull3, // That Bag Is Full.
-        VendorSoldOut2, // That Item Is Currently Sold Out.
-        ObjectIsBusy, // That Object Is Busy.
-        CantBeDisenchanted, // Item Cannot Be Disenchanted
-        NotInCombat, // You Can'T Do That While In Combat
-        NotWhileDisarmed, // You Can'T Do That While Disarmed
-        BagFull4, // That Bag Is Full.
-        CantEquipRank, // You Don'T Have The Required Rank For That Item
-        CantEquipReputation, // You Don'T Have The Required Reputation For That Item
-        TooManySpecialBags, // You Cannot Equip Another Bag Of That Type
-        LootCantLootThatNow, // You Can'T Loot That Item Now.
-        ItemUniqueEquippable, // You Cannot Equip More Than One Of Those.
-        VendorMissingTurnins, // You Do Not Have The Required Items For That Purchase
-        NotEnoughHonorPoints, // You Don'T Have Enough Honor Points
-        NotEnoughArenaPoints, // You Don'T Have Enough Arena Points
-        ItemMaxCountSocketed, // You Have The Maximum Number Of Those Gems In Your Inventory Or Socketed Into Items.
-        MailBoundItem, // You Can'T Mail Soulbound Items.
-        InternalBagError2, // Internal Bag Error
-        BagFull5, // That Bag Is Full.
-        ItemMaxCountEquippedSocketed, // You Have The Maximum Number Of Those Gems Socketed Into Equipped Items.
-        ItemUniqueEquippableSocketed, // You Cannot Socket More Than One Of Those Gems Into A Single Item.
-        TooMuchGold, // At Gold Limit
-        NotDuringArenaMatch, // You Can'T Do That While In An Arena Match
-        TradeBoundItem, // You Can'T Trade A Soulbound Item.
-        CantEquipRating, // You Don'T Have The Personal, Team, Or Battleground Rating Required To Buy That Item
+        CantEquipLevel,
+        CantEquipSkill,
+        WrongSlot,
+        BagFull,
+        BagInBag,
+        TradeEquippedBag,
+        AmmoOnly,
+        ProficiencyNeeded,
+        NoSlotAvailable,
+        CantEquipEver,
+        CantEquipEver2,
+        NoSlotAvailable2,
+        Equipped2handed,
+        TwoHandSkillNotFound,
+        WrongBagType,
+        WrongBagType2,
+        ItemMaxCount,
+        NoSlotAvailable3,
+        CantStack,
+        NotEquippable,
+        CantSwap,
+        SlotEmpty,
+        ItemNotFound,
+        DropBoundItem,
+        OutOfRange,
+        TooFewToSplit,
+        SplitFailed,
+        SpellFailedReagentsGeneric,
+        NotEnoughMoney,
+        NotABag,
+        DestroyNonemptyBag,
+        NotOwner,
+        OnlyOneQuiver,
+        NoBankSlot,
+        NoBankHere,
+        ItemLocked,
+        GenericStunned,
+        PlayerDead,
+        ClientLockedOut,
+        InternalBagError,
+        OnlyOneBolt,
+        OnlyOneAmmo,
+        CantWrapStackable,
+        CantWrapEquipped,
+        CantWrapWrapped,
+        CantWrapBound,
+        CantWrapUnique,
+        CantWrapBags,
+        LootGone,
+        InvFull,
+        BankFull,
+        VendorSoldOut,
+        BagFull2,
+        ItemNotFound2,
+        CantStack2,
+        BagFull3,
+        VendorSoldOut2,
+        ObjectIsBusy,
+        CantBeDisenchanted,
+        NotInCombat,
+        NotWhileDisarmed,
+        BagFull4,
+        CantEquipRank,
+        CantEquipReputation,
+        TooManySpecialBags,
+        LootCantLootThatNow,
+        ItemUniqueEquippable,
+        VendorMissingTurnins,
+        NotEnoughHonorPoints,
+        NotEnoughArenaPoints,
+        ItemMaxCountSocketed,
+        MailBoundItem,
+        InternalBagError2,
+        BagFull5,
+        ItemMaxCountEquippedSocketed,
+        ItemUniqueEquippableSocketed,
+        TooMuchGold,
+        NotDuringArenaMatch,
+        TradeBoundItem,
+        CantEquipRating,
     };
 
     public enum InventoryResult

--- a/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
@@ -201,10 +201,14 @@ namespace HermesProxy.World.Server
         void HandleWrapItem(WrapItem item)
         {
             WorldPacket packet = new WorldPacket(Opcode.CMSG_WRAP_ITEM);
-            packet.WriteUInt8(item.GiftBag);
-            packet.WriteUInt8(item.GiftSlot);
-            packet.WriteUInt8(item.ItemBag);
-            packet.WriteUInt8(item.ItemSlot);
+            byte GiftBag = item.GiftBag != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.GiftBag) : item.GiftBag;
+            byte GiftSlot = item.GiftSlot == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.GiftSlot) : item.GiftSlot;
+            byte ItemBag = item.ItemBag != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.ItemBag) : item.ItemBag;
+            byte ItemSlot = item.ItemSlot == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.ItemSlot) : item.ItemSlot;
+            packet.WriteUInt8(GiftBag);
+            packet.WriteUInt8(GiftSlot);
+            packet.WriteUInt8(ItemBag);
+            packet.WriteUInt8(ItemSlot);
             SendPacketToServer(packet);
         }
     }

--- a/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
@@ -201,14 +201,14 @@ namespace HermesProxy.World.Server
         void HandleWrapItem(WrapItem item)
         {
             WorldPacket packet = new WorldPacket(Opcode.CMSG_WRAP_ITEM);
-            byte GiftBag = item.GiftBag != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.GiftBag) : item.GiftBag;
-            byte GiftSlot = item.GiftBag == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.GiftSlot) : item.GiftSlot;
-            byte ItemBag = item.ItemBag != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.ItemBag) : item.ItemBag;
-            byte ItemSlot = item.ItemBag == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.ItemSlot) : item.ItemSlot;
-            packet.WriteUInt8(GiftBag);
-            packet.WriteUInt8(GiftSlot);
-            packet.WriteUInt8(ItemBag);
-            packet.WriteUInt8(ItemSlot);
+            byte giftBag = item.GiftBag != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.GiftBag) : item.GiftBag;
+            byte giftSlot = item.GiftBag == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.GiftSlot) : item.GiftSlot;
+            byte itemBag = item.ItemBag != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.ItemBag) : item.ItemBag;
+            byte itemSlot = item.ItemBag == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.ItemSlot) : item.ItemSlot;
+            packet.WriteUInt8(giftBag);
+            packet.WriteUInt8(giftSlot);
+            packet.WriteUInt8(itemBag);
+            packet.WriteUInt8(itemSlot);
             SendPacketToServer(packet);
         }
     }

--- a/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
@@ -202,9 +202,9 @@ namespace HermesProxy.World.Server
         {
             WorldPacket packet = new WorldPacket(Opcode.CMSG_WRAP_ITEM);
             byte GiftBag = item.GiftBag != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.GiftBag) : item.GiftBag;
-            byte GiftSlot = item.GiftSlot == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.GiftSlot) : item.GiftSlot;
+            byte GiftSlot = item.GiftBag == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.GiftSlot) : item.GiftSlot;
             byte ItemBag = item.ItemBag != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.ItemBag) : item.ItemBag;
-            byte ItemSlot = item.ItemSlot == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.ItemSlot) : item.ItemSlot;
+            byte ItemSlot = item.ItemBag == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.ItemSlot) : item.ItemSlot;
             packet.WriteUInt8(GiftBag);
             packet.WriteUInt8(GiftSlot);
             packet.WriteUInt8(ItemBag);

--- a/HermesProxy/World/Server/Packets/ItemPackets.cs
+++ b/HermesProxy/World/Server/Packets/ItemPackets.cs
@@ -506,6 +506,8 @@ namespace HermesProxy.World.Server.Packets
 
         public override void Write()
         {
+            if ((sbyte)BagResult >= 29)
+                BagResult+=1;
             _worldPacket.WriteInt8((sbyte)BagResult);
             _worldPacket.WritePackedGuid128(Item[0]);
             _worldPacket.WritePackedGuid128(Item[1]);

--- a/HermesProxy/World/Server/Packets/ItemPackets.cs
+++ b/HermesProxy/World/Server/Packets/ItemPackets.cs
@@ -506,8 +506,6 @@ namespace HermesProxy.World.Server.Packets
 
         public override void Write()
         {
-            if ((sbyte)BagResult >= 29)
-                BagResult+=1;
             _worldPacket.WriteInt8((sbyte)BagResult);
             _worldPacket.WritePackedGuid128(Item[0]);
             _worldPacket.WritePackedGuid128(Item[1]);


### PR DESCRIPTION
This PR fixes a mismatch in inventory results between the legacy clients and the classic clients.

- closes https://github.com/WowLegacyCore/HermesProxy/issues/62

Edit: Tested on 1.14, too