### PR TITLE
Added 'Power Word: Fortitude' EffectBasePoints

### DIFF
--- a/HermesProxy/CSV/SpellEffectPoints1.csv
+++ b/HermesProxy/CSV/SpellEffectPoints1.csv
@@ -1,0 +1,7 @@
+SpellId,SpellName,EffectBasePoints1,EffectBasePoints2,EffectBasePoints3
+1243,Power Word: Fortitude(Rank 1),2,0,0
+1244,Power Word: Fortitude(Rank 2),7,0,0
+1245,Power Word: Fortitude(Rank 3),19,0,0
+2791,Power Word: Fortitude(Rank 4),31,0,0
+10937,Power Word: Fortitude(Rank 5),42,0,0
+10938,Power Word: Fortitude(Rank 6),53,0,0

--- a/HermesProxy/CSV/SpellEffectPoints2.csv
+++ b/HermesProxy/CSV/SpellEffectPoints2.csv
@@ -1,0 +1,7 @@
+SpellId,SpellName,EffectBasePoints1,EffectBasePoints2,EffectBasePoints3
+1243,Power Word: Fortitude(Rank 1),2,0,0
+1244,Power Word: Fortitude(Rank 2),7,0,0
+1245,Power Word: Fortitude(Rank 3),19,0,0
+2791,Power Word: Fortitude(Rank 4),31,0,0
+10937,Power Word: Fortitude(Rank 5),42,0,0
+10938,Power Word: Fortitude(Rank 6),53,0,0

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1127,6 +1127,9 @@ namespace HermesProxy.World.Client
             if (GameData.StackableAuras.Contains(spellId))
                 data.Applications++;
 
+            if (GameData.SpellEffectPoints.TryGetValue(spellId, out var basePoints))
+                data.Points = basePoints;
+
             return data;
         }
 

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -29,6 +29,7 @@ namespace HermesProxy.World
         public static Dictionary<uint, uint> TransportPeriods = new Dictionary<uint, uint>();
         public static Dictionary<uint, string> AreaNames = new Dictionary<uint, string>();
         public static HashSet<uint> DispellSpells = new HashSet<uint>();
+        public static Dictionary<uint, List<float>> SpellEffectPoints = new();
         public static HashSet<uint> StackableAuras = new HashSet<uint>();
         public static HashSet<uint> MountAuras = new HashSet<uint>();
         public static HashSet<uint> NextMeleeSpells = new HashSet<uint>();
@@ -357,6 +358,7 @@ namespace HermesProxy.World
             LoadTransports();
             LoadAreaNames();
             LoadDispellSpells();
+            LoadSpellEffectPoints();
             LoadStackableAuras();
             LoadMountAuras();
             LoadMeleeSpells();
@@ -709,6 +711,43 @@ namespace HermesProxy.World
 
                     uint spellId = UInt32.Parse(fields[0]);
                     DispellSpells.Add(spellId);
+                }
+            }
+        }
+
+        public static void LoadSpellEffectPoints()
+        {
+            var path = Path.Combine("CSV", $"SpellEffectPoints{LegacyVersion.ExpansionVersion}.csv");
+            using (TextFieldParser csvParser = new TextFieldParser(path))
+            {
+                csvParser.CommentTokens = new string[] { "#" };
+                csvParser.SetDelimiters(new string[] { "," });
+                csvParser.HasFieldsEnclosedInQuotes = false;
+
+                // Skip the row with the column names
+                csvParser.ReadLine();
+
+                while (!csvParser.EndOfData)
+                {
+                    // Read current line fields, pointer moves to the next line.
+                    string[] fields = csvParser.ReadFields();
+
+                    uint spellId = UInt32.Parse(fields[0]);
+
+                    // Those basePoints are usually incremented by 1, only few test spell have another value there (baseDice)
+                    int basePointsEff1 = int.Parse(fields[2]);
+                    if (basePointsEff1 != 0)
+                        basePointsEff1 += 1;
+
+                    int basePointsEff2 = int.Parse(fields[3]);
+                    if (basePointsEff2 != 0)
+                        basePointsEff2 += 1;
+
+                    int basePointsEff3 = int.Parse(fields[4]);
+                    if (basePointsEff3 != 0)
+                        basePointsEff3 += 1;
+
+                    SpellEffectPoints.Add(spellId, new List<float>{ basePointsEff1, basePointsEff2, basePointsEff3 });
                 }
             }
         }


### PR DESCRIPTION
Apparently only pw:f 1-6 are using `Attributes[8] & AURA_ON_CLIENT` from `spellmisc` (and displaying the value).
(`AURA_ON_CLIENT = 0x00001000`)

There are other auras that use this too but display a fixed when hovering.

Fixed #148