### PR TITLE
Add SupportTicketSubmitComplaint handler

### DIFF
--- a/Framework/IO/ByteBuffer.cs
+++ b/Framework/IO/ByteBuffer.cs
@@ -162,6 +162,16 @@ namespace Framework.IO
             return (uint)Time.GetUnixTimeFromPackedTime(ReadUInt32());
         }
 
+        public DateTime ReadTime()
+        {
+            return DateTimeOffset.FromUnixTimeSeconds(ReadUInt32()).DateTime;
+        }
+
+        public DateTime ReadTime64()
+        {
+            return DateTimeOffset.FromUnixTimeSeconds((int)ReadUInt64()).DateTime;
+        }
+
         public Vector2 ReadVector2()
         {
             return new Vector2(ReadFloat(), ReadFloat());
@@ -198,7 +208,7 @@ namespace Framework.IO
         }
 
         //BitPacking
-        public byte ReadBit()
+        public bool ReadBit()
         {
             if (_bitPosition == 8)
             {
@@ -207,10 +217,10 @@ namespace Framework.IO
             }
 
             int returnValue = BitValue;
-            BitValue = (byte)(2 * returnValue);
+            BitValue = (byte)(2 * returnValue); // BitValue <<= 1;
             ++_bitPosition;
 
-            return (byte)(returnValue >> 7);
+            return (returnValue >> 7) != 0;
         }
 
         public bool HasBit()

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -7,6 +7,7 @@ using HermesProxy.World.Server;
 using System.Collections.Generic;
 using System.Linq;
 using Framework.Realm;
+using HermesProxy.World.Server.Packets;
 using ArenaTeamInspectData = HermesProxy.World.Server.Packets.ArenaTeamInspectData;
 
 namespace HermesProxy
@@ -892,6 +893,16 @@ namespace HermesProxy
             }
 
             GameState = GameSessionData.CreateNewGameSessionData(this);
+        }
+
+        public void SendSystemTextMessage(string message)
+        {
+            var socket = InstanceSocket;
+            if (socket != null)
+            {
+                var chatPkt = new ChatPkt(this, ChatMessageTypeModern.System, message);
+                socket.SendPacket(chatPkt);
+            }
         }
     }
 }

--- a/HermesProxy/World/Client/PacketHandlers/SupportTicketHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SupportTicketHandler.cs
@@ -1,0 +1,23 @@
+using HermesProxy.World.Enums;
+
+namespace HermesProxy.World.Client
+{
+    public partial class WorldClient
+    {
+        [PacketHandler(Opcode.SMSG_GM_TICKET_CREATE)]
+        void HandleGmTicketCreate(WorldPacket packet)
+        {
+            var response = (LegacyGmTicketResponse) packet.ReadUInt32();
+            switch (response)
+            {
+                case LegacyGmTicketResponse.CreateSuccess:
+                case LegacyGmTicketResponse.UpdateSuccess:
+                    Session.SendSystemTextMessage($"GM Ticket Status: |cFF00FF00{response}|r");
+                    break;
+                default:
+                    Session.SendSystemTextMessage($"GM Ticket Status: |cFFFF0000{response}|r");
+                    break;
+            }
+        }
+    }
+}

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -42,6 +42,8 @@ namespace HermesProxy.World.Client
             return _globalSession;
         }
 
+        public GlobalSessionData Session => _globalSession;
+
         public bool ConnectToWorldServer(Realm realm, GlobalSessionData globalSession)
         {
             _worldCrypt = null;

--- a/HermesProxy/World/Enums/SupportTicketDefines.cs
+++ b/HermesProxy/World/Enums/SupportTicketDefines.cs
@@ -1,0 +1,28 @@
+namespace HermesProxy.World.Enums
+{
+    enum LegacyGmTicketResponse : uint
+    {
+        TicketDoesNotExist  = 0,
+        AlreadyExist        = 1,
+        CreateSuccess       = 2,
+        CreateError         = 3,
+        UpdateSuccess       = 4,
+        UpdateError         = 5,
+        TicketDeleted       = 9,
+    };
+
+    public enum GmTicketSystemStatus
+    {
+        TicketQueueDisables = 0,
+        TicketQueueEnabled = 1,
+    }
+
+    public enum GmTicketComplaintType
+    {
+        MailSpamOrHadNoPreviousInteraction = 0,
+        Name = 3,
+        Cheating = 4,
+        ChatSpam = 9,
+        BadLanguageUsed = 11,
+    }
+}

--- a/HermesProxy/World/Server/PacketHandlers/SupportTicketHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SupportTicketHandler.cs
@@ -1,0 +1,52 @@
+using System;
+using HermesProxy.Enums;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Server.Packets;
+
+namespace HermesProxy.World.Server
+{
+    public partial class WorldSocket
+    {
+        [PacketHandler(Opcode.CMSG_SUPPORT_TICKET_SUBMIT_COMPLAINT)]
+        void HandleSupportTicketSubmitComplaint(SupportTicketSubmitComplaint complaint)
+        {
+            var targetPlayerName = Session.GameState.GetPlayerName(complaint.TargetCharacterGuid);
+
+            string ticketText = $"I would like to report player '{targetPlayerName}' (id: {complaint.TargetCharacterGuid.GetCounter()}).";
+            if (complaint.SelectedMailInfo != null)
+            {
+                ticketText += "\r\n" + $"Mail in question (id: {complaint.SelectedMailInfo.MailId}) with subject '{complaint.SelectedMailInfo.MailSubject}'";
+            }
+
+            if (!complaint.TextNote.IsEmpty())
+            {
+                ticketText += "\r\n" + "-------------";
+                ticketText += "\r\n" + complaint.TextNote;
+            }
+
+            WorldPacket packet = new WorldPacket(Opcode.CMSG_GM_TICKET_CREATE);
+
+            if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
+            {
+                packet.WriteUInt8(2); // GMTICKET_BEHAVIOR_HARASSMENT
+                packet.WriteUInt32(complaint.Header.SelfPlayerMapId);
+                packet.WriteVector3(complaint.Header.SelfPlayerPos);
+                packet.WriteCString(ticketText);
+                packet.WriteCString(""); // Not used
+            }
+            else
+            {
+                packet.WriteUInt32(complaint.Header.SelfPlayerMapId);
+                packet.WriteVector3(complaint.Header.SelfPlayerPos);
+                packet.WriteCString(ticketText);
+                packet.WriteUInt32(0); // we dont need the gm to reach back
+
+                packet.WriteUInt32(0); // chat lines count
+                packet.WriteUInt32(0); // chat text inflated size
+                packet.WriteBytes(Array.Empty<byte>()); // rest of the message are deflated chat lines
+            }
+
+            SendPacketToServer(packet);
+        }
+    }
+}

--- a/HermesProxy/World/Server/Packets/SupportTicketPackets.cs
+++ b/HermesProxy/World/Server/Packets/SupportTicketPackets.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using Framework.GameMath;
+using Framework.Logging;
+using HermesProxy.World.Enums;
+
+namespace HermesProxy.World.Server.Packets
+{
+    public class SupportTicketSubmitComplaint : ClientPacket
+    {
+        public SupportTicketSubmitComplaint(WorldPacket packet) : base(packet) { }
+
+        public override void Read()
+        {
+            Header.Read(_worldPacket);
+            TargetCharacterGuid = _worldPacket.ReadPackedGuid128();
+            ChatLog.Read(_worldPacket);
+
+            ComplaintType = (GmTicketComplaintType)_worldPacket.ReadBits<uint>(5);
+
+            var noteLength = _worldPacket.ReadBits<uint>(10); // this is somehow set to 120 when reporting mail spam(?)
+
+            var unk0 = _worldPacket.ReadBit(); // Always false?
+            var unk1 = _worldPacket.ReadBit(); // Always false?
+            var unk2 = _worldPacket.ReadBit(); // Always false?
+            var unk3 = _worldPacket.ReadBit(); // Always false?
+            var unk4 = _worldPacket.ReadBit(); // Always false?
+            var unk5 = _worldPacket.ReadBit(); // Always false?
+            var rightClickedMenu = _worldPacket.ReadBit();
+            var hasMailInfo = _worldPacket.ReadBit();
+
+            _worldPacket.ResetBitPos();
+
+            var unkZero1 = _worldPacket.ReadUInt8(); // Always 0?
+            var unkZero2 = _worldPacket.ReadUInt32(); // Always 0?
+
+            if (unk0 || unk1 || unk2 || unk3 || unk4 || unk5 || unkZero1 != 0 || unkZero2 != 0)
+            {
+                Log.Print(LogType.Error, "You reported something that we do not handle (?)");
+                Log.Print(LogType.Error, "Please create a new issue on GitHub and tell us what you did");
+                return;
+            }
+
+            if (rightClickedMenu)
+            {
+                // No data?
+            }
+
+            if (hasMailInfo)
+            {
+                SelectedMailInfo = new MailInfo();
+                SelectedMailInfo.Read(_worldPacket);
+            }
+
+            TextNote = _worldPacket.ReadString(noteLength);
+        }
+
+        public HeaderInfo Header = new();
+        public WowGuid128 TargetCharacterGuid;
+        public ChatLogInfo ChatLog = new();
+        public MailInfo? SelectedMailInfo = null;
+        public GmTicketComplaintType ComplaintType;
+        public string TextNote;
+        
+        public class HeaderInfo
+        {
+            public void Read(WorldPacket worldPacket)
+            {
+                SelfPlayerMapId = worldPacket.ReadUInt32();
+                SelfPlayerPos = worldPacket.ReadVector3();
+                SelfPlayerOrientation = worldPacket.ReadFloat();
+            }
+
+            public uint SelfPlayerMapId;
+            public Vector3 SelfPlayerPos;
+            public float SelfPlayerOrientation;
+        }
+
+        public class ChatLogInfo
+        {
+            public void Read(WorldPacket worldPacket)
+            {
+                var chatLogLineCount = worldPacket.ReadUInt32();
+                var hasReportedLineIndex = worldPacket.ReadBit();
+                for (var i = 0; i < chatLogLineCount; i++)
+                {
+                    var time = worldPacket.ReadTime64(); 
+                    var textLength = worldPacket.ReadBits<uint>(12);
+                    worldPacket.ResetBitPos();
+                    var text = worldPacket.ReadString(textLength);
+                    ChatLines.Add(new ChatLine
+                    {
+                        Time = time,
+                        Text = text,
+                    });
+                }
+
+                if (hasReportedLineIndex)
+                    ReportedLineIdx = worldPacket.ReadUInt32();
+            }
+
+            public List<ChatLine> ChatLines = new();
+            public uint? ReportedLineIdx;
+
+            public class ChatLine
+            {
+                public DateTime Time;
+                public string Text;
+            }
+        }
+
+        public class MailInfo
+        {
+            public void Read(WorldPacket worldPacket)
+            {
+                MailId = worldPacket.ReadUInt32();
+                
+                var textBodyLength = worldPacket.ReadBits<uint>(13);
+                var subjectLength = worldPacket.ReadBits<uint>(9);
+                worldPacket.ResetBitPos();
+
+                MailTextBody = worldPacket.ReadString(textBodyLength);
+                MailSubject = worldPacket.ReadString(subjectLength);
+            }
+            
+            public uint MailId;
+            public string MailTextBody;
+            public string MailSubject;
+        }
+    }
+}

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -98,6 +98,8 @@ namespace HermesProxy.World.Server
             return _globalSession;
         }
 
+        public GlobalSessionData Session => _globalSession;
+
         public override void Accept()
         {
             string ip_address = GetRemoteIpAddress().ToString();


### PR DESCRIPTION
The modern client supports right-clicking to report a player.
Previously the client just said "That you for your report!" without actually doing anything.
![image](https://user-images.githubusercontent.com/7039020/215340568-85cf9e5c-5d96-4e6b-b689-73384a0fd2ac.png)

This pull-request will create a new ticket, since there is no real reporting function in legacy clients.
I have no idea how the `SupportTicketSubmitComplaint` is acutally encoded.
And the structs from TC-master or WPP seem to not fit the 1.14.x / 2.5.x structs, weird.

The current implementation seems to work.
I will merge this feature and hope that someone will report an issue with it.
