### PR TITLE
Add CombatMiscInfo to ChatMessageTypes for Vanilla

### DIFF
--- a/HermesProxy/World/Enums/ChatMessageType.cs
+++ b/HermesProxy/World/Enums/ChatMessageType.cs
@@ -33,6 +33,7 @@ namespace HermesProxy.World.Enums
         Ignored = 22,
         Skill = 23,
         Loot = 24,
+        CombatMiscInfo = 25,
         MonsterWhisper = 26,
         MonsterParty = 48,
         BattlegroundNeutral = 82,


### PR DESCRIPTION
This PR adds the missing CombatMiscInfo (25) to the Vanilla definitions for ChatMessageTypes.
CombatMiscInfo ( https://wowpedia.fandom.com/wiki/CHAT_MSG_COMBAT_MISC_INFO ) is used for durability loss messages and similar.

To confirm that this is indeed correct, create an addon that registers itself for CHAT_MSG_COMBAT_MISC_INFO events and from the serverside send a chat message of messagetype 0x19, the addon will detect the message, confirming that this is indeed the correct id for this message type in vanilla.

```lua
local f = CreateFrame("Frame")

f:RegisterEvent("CHAT_MSG_COMBAT_MISC_INFO")

f:SetScript("OnEvent", function(self)    	
    local msg = arg1
    print (msg)
end)
```