### PR TITLE
Fix for a bug causing walking to be activated by overlapping CC on vmangos servers.

### DIFF
--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -179,6 +179,10 @@ namespace HermesProxy.World.Server
             WorldPacket packet = new WorldPacket(Opcode.CMSG_MOVE_SPLINE_DONE);
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_2_0_10192))
                 packet.WritePackedGuid(movement.Guid.To64());
+            // The modern client sends the falling flag in every spline done packet, while the 1.12 client never sends it.
+            // Sending the falling flag when the player is rooted triggers the vmangos anticheat.
+            if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
+                movement.MoveInfo.Flags &= ~(uint)MovementFlagModern.Falling;
             movement.MoveInfo.WriteMovementInfoLegacy(packet);
             packet.WriteInt32(movement.SplineID);
             if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))


### PR DESCRIPTION
The modern client sends the falling flag in every MOVE_SPLINE_DONE packet and this can trigger the movement rooted condition in the vmangos anticheat if the player is rooted at the end of the spline movement. If the anticheat is set up to reject the movement it restores the previous movement flags, which include walking for auras with the confuse mechanic like blind, polymorph, or scatter shot. Simply removing the flag should fix the issue and since the 1.12 doesn't seem to use the falling flag in the spline done packets, it shouldn't cause any problems. 
There are other ways this bug can be triggered,  but those are most likely caused by an issue in the anticheat code and happen even on the vanilla client.
fixes #223, fixes #189